### PR TITLE
Fixed basic Tezos operations

### DIFF
--- a/advanced/dapps/react-dapp-v2/src/chains/tezos.ts
+++ b/advanced/dapps/react-dapp-v2/src/chains/tezos.ts
@@ -22,14 +22,14 @@ export const TezosChainData: ChainsMap = {
   mainnet: {
     name: "Tezos",
     id: "tezos:mainnet",
-    rpc: ["https://mainnet.api.tez.ie"],
+    rpc: ["https://rpc.tzbeta.net"],
     slip44: 1729,
     testnet: false,
   },
   testnet: {
     name: "Tezos Testnet",
     id: "tezos:testnet",
-    rpc: ["https://ghostnet.ecadinfra.com"],
+    rpc: ["https://rpc.ghostnet.teztnets.com"],
     slip44: 1729,
     testnet: true,
   },

--- a/advanced/wallets/react-wallet-v2/README.md
+++ b/advanced/wallets/react-wallet-v2/README.md
@@ -39,11 +39,11 @@ Your `.env.local` now contains the following environment variables:
 
 ## Navigating through example
 
-1. Initial setup and initializations happen in [_app.ts](https://github.com/WalletConnect/web-examples/blob/main/wallets/react-wallet-v2/src/pages/_app.tsx) file
-2. WalletConnect client, ethers and cosmos wallets are initialized in [useInitialization.ts ](https://github.com/WalletConnect/web-examples/blob/main/wallets/react-wallet-v2/src/hooks/useInitialization.ts) hook
-3. Subscription and handling of WalletConnect events happens in [useWalletConnectEventsManager.ts](https://github.com/WalletConnect/web-examples/blob/main/wallets/react-wallet-v2/src/hooks/useWalletConnectEventsManager.ts) hook, that opens related [Modal views](https://github.com/WalletConnect/web-examples/tree/main/wallets/react-wallet-v2/src/views) and passes them all necessary data
-4. [Modal views](https://github.com/WalletConnect/web-examples/tree/main/wallets/react-wallet-v2/src/views) are responsible for data display and handling approval or rejection actions
-5. Upon approval or rejection, modals pass the request data to [RequestHandlerUtil.ts](https://github.com/WalletConnect/web-examples/blob/main/wallets/react-wallet-v2/src/utils/RequestHandlerUtil.ts) that performs all necessary work based on the request method and returns formated json rpc result data that can be then used for WalletConnect client responses
+1. Initial setup and initializations happen in [_app.ts](https://github.com/WalletConnect/web-examples/blob/main/advanced/wallets/react-wallet-v2/src/pages/_app.tsx) file
+2. WalletConnect client, ethers and cosmos wallets are initialized in [useInitialization.ts ](https://github.com/WalletConnect/web-examples/blob/main/advanced/wallets/react-wallet-v2/src/hooks/useInitialization.ts) hook
+3. Subscription and handling of WalletConnect events happens in [useWalletConnectEventsManager.ts](https://github.com/WalletConnect/web-examples/blob/main/advanced/wallets/react-wallet-v2/src/hooks/useWalletConnectEventsManager.ts) hook, that opens related [Modal views](https://github.com/WalletConnect/web-examples/tree/main/wallets/react-wallet-v2/src/views) and passes them all necessary data
+4. [Modal views](https://github.com/WalletConnect/web-examples/tree/main/advanced/wallets/react-wallet-v2/src/views) are responsible for data display and handling approval or rejection actions
+5. Upon approval or rejection, modals pass the request data to [RequestHandlerUtil.ts](https://github.com/WalletConnect/web-examples/blob/main/advanced/wallets/react-wallet-v2/src/utils/RequestHandlerUtil.ts) that performs all necessary work based on the request method and returns formated json rpc result data that can be then used for WalletConnect client responses
 
 ## Preview of wallet and dapp examples in action
 

--- a/advanced/wallets/react-wallet-v2/src/data/TezosData.ts
+++ b/advanced/wallets/react-wallet-v2/src/data/TezosData.ts
@@ -21,7 +21,7 @@ export const TEZOS_MAINNET_CHAINS: Record<string, ChainMetadata> = {
     name: 'Tezos',
     logo: '/chain-logos/tezos.svg',
     rgb: '44, 125, 247',
-    rpc: 'https://mainnet.api.tez.ie',
+    rpc: 'https://rpc.tzbeta.net',
     namespace: 'tezos'
   }
 }
@@ -32,7 +32,7 @@ export const TEZOS_TEST_CHAINS: Record<string, ChainMetadata> = {
     name: 'Tezos Testnet',
     logo: '/chain-logos/tezos.svg',
     rgb: '44, 125, 247',
-    rpc: 'https://ghostnet.ecadinfra.com',
+    rpc: 'https://rpc.ghostnet.teztnets.com',
     namespace: 'tezos'
   }
 }

--- a/advanced/wallets/react-wallet-v2/src/lib/TezosLib.ts
+++ b/advanced/wallets/react-wallet-v2/src/lib/TezosLib.ts
@@ -55,7 +55,10 @@ export default class TezosLib {
       curve: curve ?? DEFAULT_CURVE
     }
 
-    const Tezos = new TezosToolkit('https://mainnet.api.tez.ie')
+    // TODO: https://github.com/trilitech/web-examples/issues/2
+    // Hardcoded Tezos to use testnet
+    // Tezos should be able to switch between testnets and mainnet
+    const Tezos = new TezosToolkit('https://rpc.ghostnet.teztnets.com')
 
     const signer = InMemorySigner.fromMnemonic(params)
 


### PR DESCRIPTION
Made basic changes to fix Tezos operations in dApp and wallet:

updated RPC URIs for mainnet and ghostnet
hardcoded testnet in the wallet (Issue https://github.com/trilitech/web-examples/issues/2)
fixed links in README
After that basic Tezos operations work well:

start dapp and wallet
enable testnets in the wallet settings
top up tezos account for ghostnet
connect to Tezos on dApp side; approve on Wallet side
try operations on dApp