### PR TITLE
Fixes for error handling for dapp and wallet

### DIFF
--- a/advanced/dapps/react-dapp-v2/src/modals/RequestModal.tsx
+++ b/advanced/dapps/react-dapp-v2/src/modals/RequestModal.tsx
@@ -12,6 +12,9 @@ interface RequestModalProps {
 
 const RequestModal = (props: RequestModalProps) => {
   const { pending, result } = props;
+  if (result) {
+    console.log("Got operation result:", result);
+  }
   return (
     <>
       {pending ? (
@@ -35,7 +38,7 @@ const RequestModal = (props: RequestModalProps) => {
             {Object.keys(result).map((key) => (
               <SRow key={key}>
                 <SKey>{key}</SKey>
-                <SValue>{result[key].toString()}</SValue>
+                <SValue>{result[key]?.toString() ?? "undefined"}</SValue>
               </SRow>
             ))}
           </STable>

--- a/advanced/wallets/react-wallet-v2/src/components/ModalFooter.tsx
+++ b/advanced/wallets/react-wallet-v2/src/components/ModalFooter.tsx
@@ -53,7 +53,7 @@ export default function ModalFooter({
           auto
           flat
           style={{ color: 'white', backgroundColor: 'grey' }}
-          onPress={onReject}
+          onClick={onReject}
           data-testid="session-reject-button"
           disabled={disableReject || rejectLoader?.active}
         >
@@ -68,7 +68,7 @@ export default function ModalFooter({
           flat
           color={approveButtonColor}
           disabled={disableApprove || approveLoader?.active}
-          onPress={onApprove}
+          onClick={onApprove}
           data-testid="session-approve-button"
         >
           {approveLoader && approveLoader.active ? (


### PR DESCRIPTION
Buttons Approve/Reject were often ignored: 
- changed from onPress() to onClick()

Exceptions in Wallet were not reported to dApp
 - added handling for exceptions and reporting them to dApp

Undefined result on dApp was leading to exception in result modal
- added a default value