### PR TITLE
feat: adding Tezos operation kinds: transaction, origination, delegation

### DIFF
--- a/advanced/dapps/react-dapp-v2/src/components/Blockchain.tsx
+++ b/advanced/dapps/react-dapp-v2/src/components/Blockchain.tsx
@@ -139,6 +139,12 @@ const Blockchain: FC<PropsWithChildren<BlockchainProps>> = (
     typeof account !== "undefined" && typeof balances !== "undefined"
       ? balances[account]
       : [];
+
+  console.log("Fetched blockchain actions list ", actions); // Debug log
+
+  const [showDescription, setShowDescription] = React.useState(false);
+  const [hoveredDescription, setHoveredDescription] = React.useState<string | null>(null);
+
   return (
     <React.Fragment>
       <SAccount
@@ -181,12 +187,23 @@ const Blockchain: FC<PropsWithChildren<BlockchainProps>> = (
                       left
                       rgb={chain.meta.rgb}
                       onClick={() => action.callback(chainId, address)}
+                      onMouseEnter={() => {
+                        setShowDescription(true);
+                        setHoveredDescription(JSON.stringify(action.description, null, 2));
+                      }}
+                      onMouseLeave={() => {
+                        setShowDescription(false);
+                        setHoveredDescription(null);
+                      }}
                     >
                       {action.method}
                     </SAction>
                   ))}
                 </SFullWidthContainer>
               ) : null}
+              {showDescription && hoveredDescription && (
+                <pre style={{ textAlign: 'left' }}>{hoveredDescription}</pre>
+              )}
             </>
           )}
         </SBlockchainChildrenContainer>

--- a/advanced/dapps/react-dapp-v2/src/constants/default.ts
+++ b/advanced/dapps/react-dapp-v2/src/constants/default.ts
@@ -248,6 +248,7 @@ export enum DEFAULT_TEZOS_METHODS {
   TEZOS_GET_ACCOUNTS = "tezos_getAccounts",
   TEZOS_SEND = "tezos_send",
   TEZOS_SEND_TRANSACTION = "tezos_send:transaction",
+  TEZOS_SEND_ORGINATION = "tezos_send:origination",
   TEZOS_SIGN = "tezos_sign",
 }
 
@@ -256,6 +257,28 @@ export const DEFAULT_TEZOS_KINDS = {
       kind: "transaction",
       amount: "1", // 1 mutez, smallest unit
       destination: "$(address)", // send to ourselves
+      mutez: true,
+  },
+  "tezos_send:origination": {
+      kind: "origination",
+      source: "$(address)",
+      balance: '0',
+      code: [
+          { prim: 'parameter', args: [{ prim: 'unit' }] },
+          { prim: 'storage', args: [{ prim: 'unit' }] },
+          {
+              prim: 'code',
+              args: [
+                  [
+                      { prim: 'DROP' },
+                      { prim: 'UNIT' },
+                      { prim: 'NIL', args: [{ prim: 'operation' }] },
+                      { prim: 'PAIR' },
+                  ],
+              ],
+          },
+      ],
+      init: { prim: 'Unit' },
   },
 };
 

--- a/advanced/dapps/react-dapp-v2/src/constants/default.ts
+++ b/advanced/dapps/react-dapp-v2/src/constants/default.ts
@@ -247,8 +247,17 @@ export enum DEFAULT_TRON_EVENTS {}
 export enum DEFAULT_TEZOS_METHODS {
   TEZOS_GET_ACCOUNTS = "tezos_getAccounts",
   TEZOS_SEND = "tezos_send",
+  TEZOS_SEND_TRANSACTION = "tezos_send:transaction",
   TEZOS_SIGN = "tezos_sign",
 }
+
+export const DEFAULT_TEZOS_KINDS = {
+  "tezos_send:transaction": {
+      kind: "transaction",
+      amount: "1", // 1 mutez, smallest unit
+      destination: "$(address)", // send to ourselves
+  },
+};
 
 export enum DEFAULT_TEZOS_EVENTS {}
 

--- a/advanced/dapps/react-dapp-v2/src/constants/default.ts
+++ b/advanced/dapps/react-dapp-v2/src/constants/default.ts
@@ -249,6 +249,7 @@ export enum DEFAULT_TEZOS_METHODS {
   TEZOS_SEND = "tezos_send",
   TEZOS_SEND_TRANSACTION = "tezos_send:transaction",
   TEZOS_SEND_ORGINATION = "tezos_send:origination",
+  TEZOS_SEND_DELEGATION = "tezos_send:delegation",
   TEZOS_SIGN = "tezos_sign",
 }
 
@@ -279,6 +280,11 @@ export const DEFAULT_TEZOS_KINDS = {
           },
       ],
       init: { prim: 'Unit' },
+  },
+  "tezos_send:delegation": {
+    kind: "delegation",
+    source: "$(address)", // the address that is delegating
+    delegate: "$(address)", // the address that is being delegated to. Delegate to ourself for testing purposes
   },
 };
 

--- a/advanced/dapps/react-dapp-v2/src/contexts/JsonRpcContext.tsx
+++ b/advanced/dapps/react-dapp-v2/src/contexts/JsonRpcContext.tsx
@@ -132,6 +132,7 @@ interface IContext {
     testGetAccounts: TRpcRequestCallback;
     testSignMessage: TRpcRequestCallback;
     testSignTransaction: TRpcRequestCallback;
+    testSignOrigination: TRpcRequestCallback;
   };
   kadenaRpc: {
     testGetAccounts: TRpcRequestCallback;
@@ -1476,6 +1477,10 @@ export function JsonRpcContextProvider({
     testSignTransaction: signTransaction(
       DEFAULT_TEZOS_METHODS.TEZOS_SEND_TRANSACTION,
       DEFAULT_TEZOS_KINDS[DEFAULT_TEZOS_METHODS.TEZOS_SEND_TRANSACTION]
+    ),
+    testSignOrigination: signTransaction(
+      DEFAULT_TEZOS_METHODS.TEZOS_SEND_ORGINATION,
+      DEFAULT_TEZOS_KINDS[DEFAULT_TEZOS_METHODS.TEZOS_SEND_ORGINATION]
     ),
     testSignMessage: _createJsonRpcRequestHandler(
       async (

--- a/advanced/dapps/react-dapp-v2/src/contexts/JsonRpcContext.tsx
+++ b/advanced/dapps/react-dapp-v2/src/contexts/JsonRpcContext.tsx
@@ -133,6 +133,7 @@ interface IContext {
     testSignMessage: TRpcRequestCallback;
     testSignTransaction: TRpcRequestCallback;
     testSignOrigination: TRpcRequestCallback;
+    testSignDelegation: TRpcRequestCallback;
   };
   kadenaRpc: {
     testGetAccounts: TRpcRequestCallback;
@@ -1481,6 +1482,10 @@ export function JsonRpcContextProvider({
     testSignOrigination: signTransaction(
       DEFAULT_TEZOS_METHODS.TEZOS_SEND_ORGINATION,
       DEFAULT_TEZOS_KINDS[DEFAULT_TEZOS_METHODS.TEZOS_SEND_ORGINATION]
+    ),
+    testSignDelegation: signTransaction(
+      DEFAULT_TEZOS_METHODS.TEZOS_SEND_DELEGATION,
+      DEFAULT_TEZOS_KINDS[DEFAULT_TEZOS_METHODS.TEZOS_SEND_DELEGATION]
     ),
     testSignMessage: _createJsonRpcRequestHandler(
       async (

--- a/advanced/dapps/react-dapp-v2/src/helpers/types.ts
+++ b/advanced/dapps/react-dapp-v2/src/helpers/types.ts
@@ -152,6 +152,7 @@ export interface ChainNamespaces {
 export interface AccountAction {
   method: string;
   callback: (chainId: string, address: string) => Promise<void>;
+  description?: any;
 }
 
 export interface AccountBalances {

--- a/advanced/dapps/react-dapp-v2/src/pages/index.tsx
+++ b/advanced/dapps/react-dapp-v2/src/pages/index.tsx
@@ -20,6 +20,7 @@ import {
   DEFAULT_KADENA_METHODS,
   DEFAULT_TRON_METHODS,
   DEFAULT_TEZOS_METHODS,
+  DEFAULT_TEZOS_KINDS,
   DEFAULT_EIP155_OPTIONAL_METHODS,
   DEFAULT_EIP5792_METHODS,
   GetCapabilitiesResult,
@@ -435,8 +436,9 @@ const Home: NextPage = () => {
         callback: onGetAccounts,
       },
       {
-        method: DEFAULT_TEZOS_METHODS.TEZOS_SEND,
+        method: DEFAULT_TEZOS_METHODS.TEZOS_SEND_TRANSACTION,
         callback: onSignTransaction,
+        description: DEFAULT_TEZOS_KINDS[DEFAULT_TEZOS_METHODS.TEZOS_SEND_TRANSACTION],
       },
       {
         method: DEFAULT_TEZOS_METHODS.TEZOS_SIGN,
@@ -546,7 +548,6 @@ const Home: NextPage = () => {
   };
 
   const [openSelect, setOpenSelect] = useState(false);
-
   const openDropdown = () => {
     setOpenSelect(!openSelect);
   };

--- a/advanced/dapps/react-dapp-v2/src/pages/index.tsx
+++ b/advanced/dapps/react-dapp-v2/src/pages/index.tsx
@@ -426,6 +426,10 @@ const Home: NextPage = () => {
       openRequestModal();
       await tezosRpc.testSignTransaction(chainId, address);
     };
+    const onSignOrigination = async (chainId: string, address: string) => {
+      openRequestModal();
+      await tezosRpc.testSignOrigination(chainId, address);
+    };
     const onSignMessage = async (chainId: string, address: string) => {
       openRequestModal();
       await tezosRpc.testSignMessage(chainId, address);
@@ -439,6 +443,11 @@ const Home: NextPage = () => {
         method: DEFAULT_TEZOS_METHODS.TEZOS_SEND_TRANSACTION,
         callback: onSignTransaction,
         description: DEFAULT_TEZOS_KINDS[DEFAULT_TEZOS_METHODS.TEZOS_SEND_TRANSACTION],
+      },
+      {
+        method: DEFAULT_TEZOS_METHODS.TEZOS_SEND_ORGINATION,
+        callback: onSignOrigination,
+        description: DEFAULT_TEZOS_KINDS[DEFAULT_TEZOS_METHODS.TEZOS_SEND_ORGINATION],
       },
       {
         method: DEFAULT_TEZOS_METHODS.TEZOS_SIGN,

--- a/advanced/dapps/react-dapp-v2/src/pages/index.tsx
+++ b/advanced/dapps/react-dapp-v2/src/pages/index.tsx
@@ -430,6 +430,10 @@ const Home: NextPage = () => {
       openRequestModal();
       await tezosRpc.testSignOrigination(chainId, address);
     };
+    const onSignDelegation = async (chainId: string, address: string) => {
+      openRequestModal();
+      await tezosRpc.testSignDelegation(chainId, address);
+    };
     const onSignMessage = async (chainId: string, address: string) => {
       openRequestModal();
       await tezosRpc.testSignMessage(chainId, address);
@@ -448,6 +452,11 @@ const Home: NextPage = () => {
         method: DEFAULT_TEZOS_METHODS.TEZOS_SEND_ORGINATION,
         callback: onSignOrigination,
         description: DEFAULT_TEZOS_KINDS[DEFAULT_TEZOS_METHODS.TEZOS_SEND_ORGINATION],
+      },
+      {
+        method: DEFAULT_TEZOS_METHODS.TEZOS_SEND_DELEGATION,
+        callback: onSignDelegation,
+        description: DEFAULT_TEZOS_KINDS[DEFAULT_TEZOS_METHODS.TEZOS_SEND_DELEGATION],
       },
       {
         method: DEFAULT_TEZOS_METHODS.TEZOS_SIGN,

--- a/advanced/wallets/react-wallet-v2/src/lib/TezosLib.ts
+++ b/advanced/wallets/react-wallet-v2/src/lib/TezosLib.ts
@@ -128,6 +128,18 @@ export default class TezosLib {
             code: tx.code,
             init: tx.init,
           };
+        case 'delegation':
+          if (!tx.source || validateAddress(tx.source) !== 3) {
+            throw new Error(`tx.source contains invalid address ${tx.source}`);
+          }
+          if (!tx.delegate || validateAddress(tx.delegate) !== 3) {
+            throw new Error(`tx.delegate contains invalid address ${tx.delegate}`);
+          }
+          return {
+            kind: 'delegation',
+            source: tx.source,
+            delegate: tx.delegate,
+          };
         default:
           throw new Error(`Unsupported transaction kind: ${tx.kind}`);
       }

--- a/advanced/wallets/react-wallet-v2/src/lib/TezosLib.ts
+++ b/advanced/wallets/react-wallet-v2/src/lib/TezosLib.ts
@@ -1,6 +1,8 @@
 import { TezosToolkit } from '@taquito/taquito'
 import { InMemorySigner } from '@taquito/signer'
 import { localForger } from '@taquito/local-forging'
+import { validateAddress } from '@taquito/utils';
+
 import { Wallet } from 'ethers/'
 
 /**
@@ -88,22 +90,62 @@ export default class TezosLib {
   }
 
   public async signTransaction(transaction: any) {
-    const prepared = await this.tezos.prepare.batch(
-      transaction.map((tx: any) => ({
-        amount: tx.amount,
-        to: tx.destination,
-        kind: tx.kind,
-        mutez: true
-      }))
-    )
+    // Map the transactions and prepare the batch
+    console.log(`Wallet: handling transaction: `, transaction);
 
-    const forged = await localForger.forge(prepared.opOb)
+    const batchTransactions = transaction.map((tx: any) => {
+      switch (tx.kind) {
+        case 'transaction':
+          if (!tx.amount || isNaN(tx.amount)) {
+            throw new Error(`tx.amount is not a number: ${tx.amount}`);
+          }
+          if (!tx.destination || validateAddress(tx.destination) !== 3) {
+            throw new Error(`tx.destination contains invalid address ${tx.destination}`);
+          }
+          return {
+            kind: 'transaction',
+            amount: tx.amount,
+            to: tx.destination,
+            mutez: tx.mutez ?? false,
+          };
+        case 'origination':
+          if (!tx.source || validateAddress(tx.source) !== 3) {
+            throw new Error(`tx.source contains invalid address ${tx.source}`);
+          }
+          if (!tx.balance || isNaN(tx.balance)) {
+            throw new Error(`tx.balance is not a number: ${tx.balance}`);
+          }
+          if (!tx.code) {
+            throw new Error(`tx.code is not defined: ${tx.code}`);
+          }
+          if (!tx.init) {
+            throw new Error(`tx.init is not defined: ${tx.init}`);
+          }
+          return {
+            kind: 'origination',
+            source: tx.source,
+            balance: tx.balance,
+            code: tx.code,
+            init: tx.init,
+          };
+        default:
+          throw new Error(`Unsupported transaction kind: ${tx.kind}`);
+      }
+    });
 
-    const tx = await this.signer.sign(forged, new Uint8Array([3]))
+    // Prepare the batch
+    console.log(`Wallet: prepared batchTransactions `, batchTransactions);
+    const batch = this.tezos.contract.batch(batchTransactions);
 
-    const hash = await this.tezos.rpc.injectOperation(tx.sbytes)
+    // Send the batch and wait for the operation hash
+    console.log(`Wallet: sending batch `, batch);
+    const operation = await batch.send();
 
-    return hash
+    // Wait for confirmation
+    await operation.confirmation();
+
+    console.log('Wallet: operation confirmed.');
+    return operation.hash;
   }
 
   public async signPayload(payload: any) {


### PR DESCRIPTION
Added support for selecting operation kind for Tezos and added 3 operation kinds:
 - TRANSACTION - sending 1 tez to itself
 - ORIGINATION - originating a basic smart contract
 - DELEGATION - delegating to itself (un-delegation is not covered)