### PR TITLE
Adding tezos-connect; using Taquito in dapp-wallet interface

### DIFF
--- a/advanced/dapps/react-dapp-v2/src/constants/default.ts
+++ b/advanced/dapps/react-dapp-v2/src/constants/default.ts
@@ -264,28 +264,28 @@ export enum DEFAULT_TEZOS_METHODS {
 const tezosTransactionOperation: PartialTezosTransactionOperation = {
   kind: TezosOperationType.TRANSACTION,
   destination: "$(peerAddress)",
-  amount: "1000"
+  amount: "100"
 };
 
 const tezosOriginationOperation: PartialTezosOriginationOperation = {
   kind: TezosOperationType.ORIGINATION,
   balance: '1',
-  script: {
+  script: { // This contract adds the parameter to the storage value
     code: [
-      { "prim": "parameter", "args": [{ "prim": "unit" }] },
-      { "prim": "storage", "args": [{ "prim": "int" }] },
-      {
-        "prim": "code",
-        "args": [[
-          { "prim": "CDR" },
-          { "prim": "PUSH", "args": [{ "prim": "int" }, { "int": "10" }] },
-          { "prim": "ADD" },
-          { "prim": "NIL", "args": [{ "prim": "operation" }] },
-          { "prim": "PAIR" }
+      { prim: "parameter", args: [{ prim: "int" }] },
+      { prim: "storage", args: [{ prim: "int" }] },
+      { prim: "code",
+        args: [[
+            { prim: "DUP" },                                // Duplicate the parameter (parameter is pushed onto the stack)
+            { prim: "CAR" },                                // Access the parameter from the stack (parameter is on top)
+            { prim: "DIP", args: [[{ prim: "CDR" }]] },     // Access the storage value (storage is on the stack)
+            { prim: "ADD" },                                // Add the parameter to the storage value
+            { prim: "NIL", args: [{ prim: "operation" }] }, // Create an empty list of operations
+            { prim: "PAIR" }                                // Pair the updated storage with the empty list of operations
         ]]
       }
     ],
-    storage: { "int": "0" }
+    storage: { int: "10" }
   }
 };
 
@@ -293,7 +293,7 @@ const tezosContractCallOperation: PartialTezosTransactionOperation = {
   kind: TezosOperationType.TRANSACTION,
   destination: "$(contractAddress)",
   amount: "0",
-  parameters: { entrypoint: "default", value: { prim: "Unit" } }
+  parameters: { entrypoint: "default", value: { int: "20" } } // Add 20 to the current storage value
 };
 
 const tezosDelegationOperation: PartialTezosDelegationOperation = {

--- a/advanced/dapps/react-dapp-v2/yarn.lock
+++ b/advanced/dapps/react-dapp-v2/yarn.lock
@@ -3203,6 +3203,10 @@
   resolved "https://registry.yarnpkg.com/@tootallnate/once/-/once-1.1.2.tgz#ccb91445360179a04e7fe6aff78c00ffc1eeaf82"
   integrity sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==
 
+"@trilitech/tezos-connect@git+ssh://git@github.com:trilitech/tezos-connect.git#diana@types":
+  version "1.0.0"
+  resolved "git+ssh://git@github.com:trilitech/tezos-connect.git#62331287c085f2256db0742a24f1efd79137c0eb"
+
 "@types/babel__core@^7.0.0", "@types/babel__core@^7.1.7":
   version "7.20.0"
   resolved "https://registry.yarnpkg.com/@types/babel__core/-/babel__core-7.20.0.tgz#61bc5a4cae505ce98e1e36c5445e4bee060d8891"

--- a/advanced/wallets/react-wallet-v2/src/lib/TezosLib.ts
+++ b/advanced/wallets/react-wallet-v2/src/lib/TezosLib.ts
@@ -1,6 +1,5 @@
-import { TezosToolkit } from '@taquito/taquito';
+import { ParamsWithKind, TezosToolkit } from '@taquito/taquito';
 import { InMemorySigner } from '@taquito/signer'
-import { validateAddress } from '@taquito/utils';
 
 import { Wallet } from 'ethers/'
 
@@ -91,64 +90,15 @@ export default class TezosLib {
   public async signTransaction(transaction: any) {
     // Map the transactions and prepare the batch
     console.log(`Wallet: handling transaction: `, transaction);
-
-    const batchTransactions = transaction.map((tx: any) => {
+    const batchTransactions: ParamsWithKind[] = transaction.map((tx: any) => {
       switch (tx.kind) {
-        case 'transaction':
-          if (!tx.amount || isNaN(tx.amount)) {
-            throw new Error(`tx.amount is not a number: ${tx.amount}`);
-          }
-          if (!tx.destination || validateAddress(tx.destination) !== 3) {
-            throw new Error(`tx.destination contains invalid address ${tx.destination}`);
-          }
-          return {
-            kind: 'transaction',
-            amount: tx.amount,
-            to: tx.destination,
-            mutez: tx.mutez ?? false,
-            parameters: tx.parameters,
-          };
-        case 'origination':
-          if (tx.source && validateAddress(tx.source) !== 3) {
-            throw new Error(`tx.source contains invalid address ${tx.source}`);
-          }
-          if (!tx.balance || isNaN(tx.balance)) {
-            throw new Error(`tx.balance is not a number: ${tx.balance}`);
-          }
-          if (!tx.script || !tx.script.code) {
-            throw new Error(`tx.script.code is not defined: ${tx.script}`);
-          }
-          if (!tx.script.storage) {
-            throw new Error(`tx.script.storage is not defined: ${tx.script}`);
-          }
-          return {
-            kind: 'origination',
-            source: tx.source,
-            balance: tx.balance,
-            code: tx.script.code,
-            init: tx.script.storage,
-            parameters: tx.parameters,
-          };
         case 'delegation':
-          if (tx.source && validateAddress(tx.source) !== 3) {
-            throw new Error(`tx.source contains invalid address ${tx.source}`);
-          }
-          if (!tx.delegate) {
-            console.log(`Wallet: undelegating for ${tx.source}`);
-            return {
-              kind: 'delegation',
-              source: tx.source,
-            };
-          } else if (validateAddress(tx.delegate) !== 3) {
-            throw new Error(`tx.delegate contains invalid address ${tx.delegate}`);
-          }
           return {
-            kind: 'delegation',
-            source: tx.source,
-            delegate: tx.delegate,
-          };
+            ...tx,
+            source: tx.source ?? this.address
+          }
         default:
-          throw new Error(`Unsupported transaction kind: ${tx.kind}`);
+          return tx as ParamsWithKind;
       }
     });
 

--- a/advanced/wallets/react-wallet-v2/src/utils/TezosRequestHandlerUtil.ts
+++ b/advanced/wallets/react-wallet-v2/src/utils/TezosRequestHandlerUtil.ts
@@ -34,8 +34,13 @@ export async function approveTezosRequest(
         const sendResponse = await wallet.signTransaction(request.params.operations)
         return formatJsonRpcResult(id, { hash: sendResponse })
       } catch (error) {
-        console.error("Tezos_send operation failed with error: ", error.message);
-        return formatJsonRpcError(id, error.message);
+        if (error instanceof Error) {
+          console.error("Tezos_send operation failed with error: ", error.message);
+          return formatJsonRpcError(id, error.message);
+        } else {
+          console.error("Tezos_send operation failed with unknown error: ", error);
+          return formatJsonRpcError(id, 'TEZOS_SEND failed with unknown error.');
+        }
       }
 
     case TEZOS_SIGNING_METHODS.TEZOS_SIGN:


### PR DESCRIPTION
- Added `tezos-connect` library to the project
- Changed the type of structures used in WalletConnect interface from Beacon to Taquito
- `react-dapp-v2`: Integrated `tezos-connect` with 
- `react-wallet-v2`: Adapted to Taquito-compatible structures in the dapp-wallet interface

### Changes

## dApp

 - The dApp now defines requests using Beacon structures (re-exported by tezos-connect), such as `PartialTezosOriginationOperation`.
 - Then dApp converts Beacon structures to Taquito types using:
```
const taquitoOperation: PartialParamsWithKind = convertToPartialParamsWithKind(operation);
```
 - Then Taquito-compatible operation is sent over WalletConnect to the wallet.

## Wallet 

- Receives requests in Taquito-compatible format.
- Delegates checks to Taquito, simplifying the implementation.
- Adds missing information to requests and restores Taquito structures from JSON.
 - The wallet now only requires the Taquito library and not `tezos-connect`.

Benefits:
- Bugs in Beacon structures are fixed before re-export by tezos-connect which simplifies dApp implementation
- Simplified wallet implementation.
- Reduced need for custom checks in the wallet.